### PR TITLE
Feature/create index component

### DIFF
--- a/components/atoms/Button/Button.js
+++ b/components/atoms/Button/Button.js
@@ -4,12 +4,12 @@ import './Button.scss'
 // const LoadMore = ({children}) => <div className="c-btn c-btn--more"><a href="#">{children}</a></div>
 // const OnlyText = ({children}) => <div className="c-btn"><a href="#">{children}</a></div>
 
-const Button = ({children}) => {
+const Button = ({ path, children }) => {
 
-  switch(children){
+  switch (children) {
     case '一覧を見る':
     case 'もっと読む':
-      return <div className="c-btn c-btn--more"><a href="#">{children}</a></div>
+      return <div className="c-btn c-btn--more"><a href={path}>{children}</a></div>
       break;
     default:
       return <div className="c-btn"><a href="#">{children}</a></div>

--- a/components/molecules/IndexArea/IndexArea.js
+++ b/components/molecules/IndexArea/IndexArea.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react'
+
+import ListPostBlogCategoryIndex from '../../molecules/ListPostBlogCategoryIndex/ListPostBlogCategoryIndex'
+import Button from '../../atoms/Button/Button'
+import TitleCategory from '../../atoms/TitleCategory/TitleCategory'
+
+class IndexArea extends Component {
+
+  render() {
+    console.log('インデックスエリア start')
+    console.log(this.props)
+    console.log('インデックスエリア　end')
+    return (
+      <div className="l-wrap__outer p-article-bloc p-article-bloc--category">
+        <div className="l-wrap__inner l-wrap__inner--top">
+
+          <dl className="p-article-bloc__title c-bloc-title">
+            <dt className="jp">{this.props.jpTitle}</dt>
+            <dd className="en">{this.props.enTitle}</dd>
+          </dl>
+
+          <div className="p-article-bloc__card-wrap">
+            <ListPostBlogCategoryIndex category={this.props.category} />
+          </div>
+
+          <div className="p-article-bloc__btn">
+            <Button path={this.props.category} >一覧を見る</Button>
+          </div>
+
+        </div>
+      </div>
+    )
+  }
+
+}
+
+export default IndexArea;

--- a/components/molecules/ListPostBlogCategoryIndex/ListPostBlogCategoryIndex.js
+++ b/components/molecules/ListPostBlogCategoryIndex/ListPostBlogCategoryIndex.js
@@ -1,0 +1,80 @@
+import React, { Component } from 'react'
+
+import fetch from 'isomorphic-unfetch'
+import { category, url, postType } from '../../../Api/Api'
+import Card from '../../atoms/Card/Card'
+
+class ListPostBlogCategoryIndex extends Component {
+  constructor(props) {
+    super(props);
+    this.isLoading = false;
+    this.fetchData = this.fetchData.bind(this);
+    this.renderPost = this.renderPost.bind(this);
+    this.state = {
+      data: [],
+      isLoaded: false,
+      categoryName: props.category
+    }
+  }
+
+  fetchData() {
+    if (this.isLoading === false) {
+      let categoryName = this.props.category
+
+      return category(categoryName, 1).then(res => res.json())
+        .then(data => {
+          this.setState({
+            data: data,
+            isLoaded: true,
+            isLoading: false
+          })
+        })
+    }
+  }
+
+  componentDidMount() {
+
+    //1回目のfetch
+    this.fetchData();
+  }
+
+  // componentDidUpdate(prevProps, prevState) {
+  //   if (this.props.route.asPath !== prevProps.route.asPath) {
+
+  //     // 2回目以降のfetch
+  //     this.fetchData();
+
+  //   }
+  // }
+
+  renderPost() {
+
+    const postMaxNum = 5;
+    const arrPost = this.state.data.posts.slice(0, postMaxNum);
+
+    const blogPost = arrPost.map((item, index) => {
+      return (
+        <Card {...item} key={item.id} lcardFlg={index < 2} route={'index'} />
+      )
+    });
+
+    if (blogPost.length > 0) {
+      return blogPost
+    } else {
+      return (
+        <p>関連記事はありません。</p>
+      )
+    }
+  }
+
+  render() {
+    if (this.state.isLoaded) {
+      return this.renderPost();
+    } else {
+      return <p>spiner</p>
+    }
+  }
+
+}
+
+export default ListPostBlogCategoryIndex;

--- a/components/organisms/ContentArea/ContentArea.js
+++ b/components/organisms/ContentArea/ContentArea.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react'
-
-import ListPost from '../../molecules/ListPost/ListPost'
-import Button from '../../atoms/Button/Button'
+import IndexArea from '../../molecules/IndexArea/IndexArea'
 
 import './ContentArea.scss'
 import './Title.scss'
@@ -9,28 +7,17 @@ import './Title.scss'
 class ContentArea extends Component {
 
   render() {
+
     return (
       <section className="l-content-area">
         <div className="l-content l-content--top">
 
-          <div className="l-wrap__outer p-article-bloc p-article-bloc--category">
-            <div className="l-wrap__inner l-wrap__inner--top">
+          <IndexArea jpTitle={'日本の古都'} enTitle={'Ancient City in Japan'} category={'/jp/ancient-city'} />
+          <IndexArea jpTitle={'日本の伝統'} enTitle={'Japan Traditional'} category={'/jp/traditional'} />
+          <IndexArea jpTitle={'日本の食文化'} enTitle={'Japanese Food Culture'} category={'/jp/culture'} />
+          <IndexArea jpTitle={'名所・旧跡'} enTitle={'Classic Ground'} category={'/jp/classic-ground'} />
+          <IndexArea jpTitle={'旅人のブログ'} enTitle={'Classic Ground'} category={'/jp/travel-blog'} />
 
-              <dl className="p-article-bloc__title c-bloc-title">
-                <dt className="jp">日本の古都</dt>
-                <dd className="en">Ancient City in Japan</dd>
-              </dl>
-
-              <div className="p-article-bloc__card-wrap">
-                <ListPost {...this.props} />
-              </div>
-
-              <div className="p-article-bloc__btn">
-                <Button>一覧を見る</Button>
-              </div>
-
-            </div>
-          </div>
         </div>
       </section>
     )


### PR DESCRIPTION
# Technical Changes
- Indexタイプのレイアウトで5件の投稿記事カードを表示するコンポーネントを作成
- Indexタイプコンポーネントをカテゴリー別に出し分けるためのロジックを作成
  - Indexタイプコンポーネントのカテゴリーごとに `タイトル` `URL` が切り替わるようにchildコンポーネントに `url` 、 `日本語タイトル` 、 `英語タイトル` を渡すように調整

